### PR TITLE
Add DarkModeContext, ThemeProviderWithDarkMode, theme toggle

### DIFF
--- a/packages/power-notes-frontend/src/navigation/components/TopBar.tsx
+++ b/packages/power-notes-frontend/src/navigation/components/TopBar.tsx
@@ -1,8 +1,8 @@
 import styles from "+styles/TopBar.module.scss";
+import { Menu } from "@mui/icons-material";
 import { IconButton } from "@mui/material";
 import React from "react";
 import { ProfileMenu } from "./ProfileMenu";
-import { Menu } from "@mui/icons-material";
 
 interface Props {
     readonly handleLeftMenuOpen: () => void;
@@ -18,7 +18,7 @@ export const TopBar = React.memo(function TopBar({
             {!isLeftMenuOpen && (
                 <IconButton
                     aria-label="menu"
-                    color="inherit"
+                    color="primary"
                     onClick={handleLeftMenuOpen}
                     disableRipple={true}
                     edge="start"

--- a/packages/power-notes-frontend/src/root/App.tsx
+++ b/packages/power-notes-frontend/src/root/App.tsx
@@ -1,4 +1,7 @@
+import { useMediaQuery } from "@mui/material";
 import { RouterProvider, createBrowserRouter } from "react-router-dom";
+import { DarkModeProvider } from "../themes/DarkModeContext";
+import { ThemeProviderWithDarkMode } from "../themes/ThemeProviderWithDarkMode";
 import { ErrorPage } from "../error/components/ErrorPage";
 import { HomePage } from "../home/HomePage";
 import { JournalHome } from "../journal/JournalHome";
@@ -38,7 +41,15 @@ const router = createBrowserRouter([
 ]);
 
 function App() {
-    return <RouterProvider router={router} />;
+    const prefersDarkMode = useMediaQuery("(prefers-color-scheme: dark)");
+
+    return (
+        <ThemeProviderWithDarkMode isDarkMode={prefersDarkMode}>
+            <DarkModeProvider initialDarkMode={prefersDarkMode}>
+                <RouterProvider router={router} />
+            </DarkModeProvider>
+        </ThemeProviderWithDarkMode>
+    );
 }
 
 export default App;

--- a/packages/power-notes-frontend/src/root/main.tsx
+++ b/packages/power-notes-frontend/src/root/main.tsx
@@ -3,17 +3,21 @@ import React from "react";
 import ReactDOM from "react-dom/client";
 import App from "./App.tsx";
 import "./index.css";
+import { ThemeProvider } from "@mui/material";
+import { BASE_APP_THEME } from "../themes/baseThemes.ts";
 
 ReactDOM.createRoot(document.getElementById("root")!).render(
-    <Auth0Provider
-        domain="dev-y2cpnxrzduhff4xe.us.auth0.com"
-        clientId="4Vgaa10GSIqKET8zlrlv5B17EokGZBVa"
-        authorizationParams={{
-            redirect_uri: window.location.origin,
-        }}
-    >
-        <React.StrictMode>
-            <App />
-        </React.StrictMode>
-    </Auth0Provider>
+    <React.StrictMode>
+        <Auth0Provider
+            domain="dev-y2cpnxrzduhff4xe.us.auth0.com"
+            clientId="4Vgaa10GSIqKET8zlrlv5B17EokGZBVa"
+            authorizationParams={{
+                redirect_uri: window.location.origin,
+            }}
+        >
+            <ThemeProvider theme={BASE_APP_THEME}>
+                <App />
+            </ThemeProvider>
+        </Auth0Provider>
+    </React.StrictMode>
 );


### PR DESCRIPTION
Make the app dark mode/light mode system aware by default and add `DarkModeProvider` to enable dark and light mode toggle in app components. Add `ThemeProviderWithDarkMode` to build off of MUI's `ThemeProvider` to enable dark/light mode-differentiated custom themes.